### PR TITLE
Fix infiltrate bugs with augments

### DIFF
--- a/src/infiltrate.js
+++ b/src/infiltrate.js
@@ -111,7 +111,7 @@ async function playMinigame(ns, targetFaction) {
       await playEnterCode(ns);
     } else if (contains(title, 'when his guard is')) {
       await playAttackGuard(ns);
-    } else if (contains(title, 'Type it backward')) {
+    } else if (contains(title, 'Type it')) {
       await playTypeBackwards(ns);
     } else if (contains(title, 'Close the brackets')) {
       await playMatchBrackets(ns);

--- a/src/infiltrate.js
+++ b/src/infiltrate.js
@@ -183,8 +183,9 @@ const playCutWires = async (ns) => {
 
   const wireColors = Array.from(doc.querySelectorAll('div > p'))
     .filter((n) => n.innerText.match(/^\|/))
-    .map((n) => n.getAttribute('style').match(/: ([redylowbuhitg]+)/)[1])
-    .map((c) => (c === 'rgb' ? 'yellow' : c));
+    .map((n) => n.getAttribute('style').match(/: (.+);/)[1])
+    .map((c) => (contains(c, 'rgb(255, 193, 7)') ? 'yellow' : c))
+    .map((c) => (contains(c, 'rgb(102, 207, 188)') ? 'gray' : c));
 
   const wireProperties = [];
   for (let j = 0; j < wireCount; j++) {


### PR DESCRIPTION
Wire cutter was treating all RGB values as yellow, but augment adds a gray color.
Type It Backwards loses the backwards and just becomes "Type It"